### PR TITLE
feat: AIレコメンド機能の実装

### DIFF
--- a/backend/DATA_FORMAT_GUIDE.md
+++ b/backend/DATA_FORMAT_GUIDE.md
@@ -1,0 +1,135 @@
+# Supabaseデータベース 手動追加ガイド
+
+## テーブル名
+Djangoのモデル名は、データベースでは以下のテーブル名になります：
+- `Sake` モデル → **`api_sake`** テーブル
+- `Brewery` モデル → **`api_brewery`** テーブル
+
+---
+
+## 1. Brewery（酒蔵）テーブル: `api_brewery`
+
+### フィールド一覧
+
+| フィールド名 | データ型 | 必須 | 説明 | 例 |
+|------------|---------|------|------|-----|
+| `id` | bigint | 自動 | 主キー（自動採番） | - |
+| `name` | varchar(200) | **必須** | 酒蔵名 | `新政酒造` |
+
+### 追加手順
+1. Supabaseダッシュボード → Table Editor → `api_brewery` を開く
+2. "Insert row" をクリック
+3. `name` フィールドに酒蔵名を入力
+4. Save をクリック
+
+### サンプルデータ
+```
+name: 新政酒造
+name: 十四代
+name: 獺祭
+name: 久保田
+name: 八海山
+```
+
+---
+
+## 2. Sake（日本酒）テーブル: `api_sake`
+
+### フィールド一覧
+
+| フィールド名 | データ型 | 必須 | 説明 | 例 |
+|------------|---------|------|------|-----|
+| `id` | bigint | 自動 | 主キー（自動採番） | - |
+| `name` | varchar(100) | **必須** | 日本酒名 | `新政 No.6 X-type` |
+| `category` | varchar(50) | **必須** | カテゴリー | `純米大吟醸` |
+| `description` | text | **必須** | 説明文 | `フルーティーで華やかな香りが特徴` |
+| `region` | varchar(100) | 任意 | 産地・地域 | `秋田県` |
+| `brewery_id` | bigint | 任意 | 酒蔵ID（外部キー） | `1`（api_breweryのidを参照） |
+| `sweetness_level` | integer | 任意 | 甘さの度合い（1:辛口 〜 5:甘口） | `2` |
+| `aroma_level` | integer | 任意 | 香りの強さ（1:控えめ 〜 5:芳醇） | `5` |
+| `alcohol_content` | double precision | 任意 | アルコール度数 | `15.0` |
+| `price_range` | varchar(50) | 任意 | 価格帯 | `3000-5000円` |
+| `created_at` | timestamp with time zone | 自動 | 作成日時（自動） | - |
+
+### 追加手順
+1. Supabaseダッシュボード → Table Editor → `api_sake` を開く
+2. "Insert row" をクリック
+3. 必須フィールドを入力：
+   - `name`: 日本酒名
+   - `category`: カテゴリー
+   - `description`: 説明文
+4. 任意フィールドを入力：
+   - `region`: 産地
+   - `brewery_id`: 酒蔵ID（`api_brewery`テーブルの`id`を参照）
+   - `sweetness_level`: 甘さ（1-5）
+   - `aroma_level`: 香り（1-5）
+   - `alcohol_content`: アルコール度数
+   - `price_range`: 価格帯
+5. Save をクリック
+
+### サンプルデータ例
+
+#### 例1: 全フィールドを入力
+```
+name: 新政 No.6 X-type
+category: 純米大吟醸
+description: フルーティーで華やかな香りが特徴の純米大吟醸酒。芳醇な香りと上品な味わいが楽しめます。
+region: 秋田県
+brewery_id: 1  （api_breweryテーブルで「新政酒造」のID）
+sweetness_level: 2
+aroma_level: 5
+alcohol_content: 15.0
+price_range: 3000-5000円
+```
+
+#### 例2: 最小限の必須フィールドのみ
+```
+name: 久保田 万寿
+category: 純米大吟醸
+description: 芳醇な香りと上品な味わいが特徴。
+```
+
+#### 例3: 地域と嗜好情報を含む
+```
+name: 獺祭 純米大吟醸50
+category: 純米大吟醸
+description: すっきりとした飲み口で、フルーティーな香りが楽しめる。
+region: 山口県
+sweetness_level: 2
+aroma_level: 4
+alcohol_content: 16.0
+price_range: 2000-4000円
+```
+
+---
+
+## データ入力時の注意点
+
+### ✅ 必須項目
+- `name`, `category`, `description` は必ず入力してください
+
+### ⚠️ 外部キー
+- `brewery_id` を入力する場合は、先に `api_brewery` テーブルに該当する酒蔵を作成してください
+- または、`brewery_id` は `NULL` のままでも問題ありません
+
+### 📝 数値フィールド
+- `sweetness_level`: 1（辛口）〜 5（甘口）
+- `aroma_level`: 1（控えめ）〜 5（芳醇）
+- `alcohol_content`: 数値（例: 15.0, 16.5）
+
+### 🕐 自動フィールド
+- `id`: 自動採番（入力不要）
+- `created_at`: 自動設定（入力不要）
+
+---
+
+## 動作確認のための推奨データ数
+
+最低でも **3〜5件** のSakeデータがあると、AIレコメンド機能の動作確認ができます。
+
+テスト用に以下のようなバリエーションを用意すると良いでしょう：
+- 異なる地域の日本酒
+- 異なる甘さレベル（辛口〜甘口）
+- 異なる香りレベル（控えめ〜芳醇）
+- 異なる価格帯
+

--- a/backend/ai_recommend/README.md
+++ b/backend/ai_recommend/README.md
@@ -1,0 +1,84 @@
+# AIレコメンド機能 動作確認手順
+
+## 前提条件
+
+1. Supabaseデータベースに接続設定済み（`.env`に`DATABASE_URL`が設定されている）
+2. OpenAI API キーが設定済み（`.env`に`OPENAI_API_KEY`が設定されている）
+3. マイグレーションが適用済み
+
+## 動作確認手順
+
+### 1. サーバー起動
+
+```bash
+cd backend
+python3 manage.py runserver
+```
+
+または、Docker Composeを使用する場合：
+```bash
+docker-compose up backend
+```
+
+### 2. APIエンドポイントの確認
+
+#### A. レコメンド生成（POST）
+
+```bash
+curl -X POST http://localhost:8000/ai_recommend/recommend/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_supa_id": "123e4567-e89b-12d3-a456-426614174000",
+    "preferred_sweetness": 3,
+    "preferred_aroma": 4,
+    "preferred_region": "新潟県",
+    "budget_min": 1000,
+    "budget_max": 5000,
+    "additional_preferences": "フルーティーな香りが好き"
+  }'
+```
+
+**注意**: 
+- `user_supa_id`は実際のSupabaseのユーザーID（UUID）を指定してください
+- Supabaseデータベースに`Sake`データが存在することが前提です
+
+#### B. レコメンド一覧取得（GET）
+
+```bash
+curl http://localhost:8000/ai_recommend/recommendations/?user_supa_id=123e4567-e89b-12d3-a456-426614174000&limit=10
+```
+
+## データについて
+
+### Supabaseデータベース上のデータ
+
+- **既存データの確認**: Supabaseダッシュボードで`api_sake`テーブルを確認
+- **新規データの追加**: SupabaseダッシュボードのSQL Editorから、またはDjango Adminから追加
+
+### テストデータが必要な場合
+
+テスト用のサンプルデータをSupabaseに追加する場合は、以下のいずれかの方法を使用：
+
+1. **SupabaseダッシュボードのTable Editorから手動で追加**
+2. **SQL EditorでINSERT文を実行**
+3. **Django Adminから追加**（`/admin/`にアクセス）
+
+**重要**: テストデータはSupabaseデータベースに直接追加されるため、チーム全体で共有されます。
+
+## トラブルシューティング
+
+### エラー: "OPENAI_API_KEY が環境変数に設定されていません"
+→ `.env`ファイルに`OPENAI_API_KEY=your-api-key`を追加してください
+
+### エラー: "No Sake objects found"
+→ Supabaseデータベースに`Sake`データが存在することを確認してください
+
+### エラー: データベース接続エラー
+→ `.env`ファイルの`DATABASE_URL`が正しく設定されているか確認してください
+
+## 次のステップ
+
+- フロントエンドUI実装（React側）
+- エラーハンドリングの改善
+- ログ機能の追加
+

--- a/backend/ai_recommend/migrations/0002_add_new_models.py
+++ b/backend/ai_recommend/migrations/0002_add_new_models.py
@@ -1,0 +1,70 @@
+# Generated manually to add UserPreference and update RecommendedItem
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0002_add_ai_recommend_fields'),
+        ('ai_recommend', '0001_initial'),
+    ]
+
+    operations = [
+        # UserPreferenceモデルを作成
+        migrations.CreateModel(
+            name='UserPreference',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('user_supa_id', models.UUIDField(db_index=True, help_text='SupabaseのUser ID')),
+                ('preferred_sweetness', models.IntegerField(blank=True, help_text='好みの甘さ（1:辛口 〜 5:甘口）', null=True)),
+                ('preferred_aroma', models.IntegerField(blank=True, help_text='好みの香り（1:控えめ 〜 5:芳醇）', null=True)),
+                ('preferred_region', models.CharField(blank=True, help_text='好みの地域', max_length=100)),
+                ('budget_min', models.IntegerField(blank=True, help_text='予算の下限（円）', null=True)),
+                ('budget_max', models.IntegerField(blank=True, help_text='予算の上限（円）', null=True)),
+                ('additional_preferences', models.TextField(blank=True, help_text='その他の希望やコメント')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                'ordering': ['-updated_at'],
+            },
+        ),
+        # RecommendedItemに新しいフィールドを追加（null=Trueで追加し、後で必須にする）
+        migrations.AddField(
+            model_name='recommendeditem',
+            name='sake',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='recommendations', to='api.sake'),
+        ),
+        migrations.AddField(
+            model_name='recommendeditem',
+            name='user_supa_id',
+            field=models.UUIDField(blank=True, db_index=True, help_text='このレコメンドを受け取ったユーザー', null=True),
+        ),
+        migrations.AddField(
+            model_name='recommendeditem',
+            name='user_preference',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='recommendations', to='ai_recommend.userpreference'),
+        ),
+        migrations.AddField(
+            model_name='recommendeditem',
+            name='gpt_reason',
+            field=models.TextField(blank=True, help_text='GPTがこのお酒を選んだ理由'),
+        ),
+        migrations.AlterField(
+            model_name='recommendeditem',
+            name='description',
+            field=models.TextField(blank=True, help_text='GPTが生成したレコメンド理由・説明'),
+        ),
+        migrations.AlterField(
+            model_name='recommendeditem',
+            name='title',
+            field=models.CharField(help_text='酒の名前（sakeから取得可能だが、GPT生成時にも保持）', max_length=200),
+        ),
+        migrations.AlterModelOptions(
+            name='recommendeditem',
+            options={'ordering': ['-score', '-created_at']},
+        ),
+    ]
+

--- a/backend/ai_recommend/migrations/0003_make_user_supa_id_required.py
+++ b/backend/ai_recommend/migrations/0003_make_user_supa_id_required.py
@@ -1,0 +1,31 @@
+# user_supa_idを必須フィールドにする
+
+from django.db import migrations, models
+
+
+def delete_null_user_recommendations(apps, schema_editor):
+    """user_supa_idがnullのRecommendedItemを削除"""
+    RecommendedItem = apps.get_model('ai_recommend', 'RecommendedItem')
+    RecommendedItem.objects.filter(user_supa_id__isnull=True).delete()
+
+
+def reverse_delete(apps, schema_editor):
+    """ロールバック時は何もしない"""
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ai_recommend', '0002_add_new_models'),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_null_user_recommendations, reverse_delete),
+        migrations.AlterField(
+            model_name='recommendeditem',
+            name='user_supa_id',
+            field=models.UUIDField(db_index=True, help_text='このレコメンドを受け取ったユーザー'),
+        ),
+    ]
+

--- a/backend/ai_recommend/models.py
+++ b/backend/ai_recommend/models.py
@@ -1,15 +1,64 @@
 from django.db import models
+from django.conf import settings
 
-from django.db import models
+
+class UserPreference(models.Model):
+    """ユーザーの嗜好情報を保存するモデル"""
+    # UUIDでユーザーを識別（他のアプリと統一）
+    user_supa_id = models.UUIDField(
+        db_index=True, help_text="SupabaseのUser ID")
+
+    # 嗜好情報
+    preferred_sweetness = models.IntegerField(
+        null=True, blank=True, help_text="好みの甘さ（1:辛口 〜 5:甘口）")
+    preferred_aroma = models.IntegerField(
+        null=True, blank=True, help_text="好みの香り（1:控えめ 〜 5:芳醇）")
+    preferred_region = models.CharField(
+        max_length=100, blank=True, help_text="好みの地域")
+    budget_min = models.IntegerField(
+        null=True, blank=True, help_text="予算の下限（円）")
+    budget_max = models.IntegerField(
+        null=True, blank=True, help_text="予算の上限（円）")
+    additional_preferences = models.TextField(
+        blank=True, help_text="その他の希望やコメント")
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        # 1ユーザーにつき1つの嗜好情報（最新のものを取得）
+        ordering = ['-updated_at']
+
+    def __str__(self):
+        return f"UserPreference: {self.user_supa_id}"
 
 
 class RecommendedItem(models.Model):
-    # 例：おすすめするスポットやコンテンツ
-    title = models.CharField(max_length=200)
-    description = models.TextField(blank=True)
+    """AIが生成したレコメンド結果を保存するモデル"""
+    # Sakeモデルとの関連付け（apiアプリのSakeモデルを参照）
+    sake = models.ForeignKey("api.Sake", on_delete=models.CASCADE,
+                             null=True, blank=True, related_name="recommendations")
+
+    # ユーザーとの関連付け
+    user_supa_id = models.UUIDField(
+        db_index=True, help_text="このレコメンドを受け取ったユーザー")
+    user_preference = models.ForeignKey(
+        UserPreference, on_delete=models.SET_NULL, null=True, blank=True, related_name="recommendations")
+
+    # レコメンド情報
+    title = models.CharField(
+        max_length=200, help_text="酒の名前（sakeから取得可能だが、GPT生成時にも保持）")
+    description = models.TextField(blank=True, help_text="GPTが生成したレコメンド理由・説明")
     category = models.CharField(max_length=100, blank=True)
-    score = models.FloatField(default=0.0)  # レコメンドスコア
+    score = models.FloatField(default=0.0, help_text="レコメンドスコア（GPTからの評価スコア）")
+
+    # GPT生成時の情報を保持（デバッグ・分析用）
+    gpt_reason = models.TextField(blank=True, help_text="GPTがこのお酒を選んだ理由")
     created_at = models.DateTimeField(auto_now_add=True)
 
+    class Meta:
+        ordering = ['-score', '-created_at']
+
     def __str__(self):
-        return f"{self.title} ({self.score})"
+        sake_name = self.sake.name if self.sake else self.title
+        return f"{sake_name} (Score: {self.score})"

--- a/backend/ai_recommend/services.py
+++ b/backend/ai_recommend/services.py
@@ -1,0 +1,165 @@
+"""
+AIレコメンド機能のサービス層
+GPTを活用してユーザーの好みに合った日本酒をレコメンドする
+"""
+import os
+import json
+from typing import List, Dict, Optional
+from openai import OpenAI
+from django.conf import settings
+from api.models import Sake
+
+
+class AIRecommendationService:
+    """GPTを活用したレコメンドサービス"""
+
+    def __init__(self):
+        # 環境変数からAPIキーを取得
+        api_key = os.getenv('OPENAI_API_KEY')
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY が環境変数に設定されていません")
+
+        # カスタムエンドポイントを設定（学校配布のAPIを使用）
+        base_url = "https://api.openai.iniad.org/api/v1"
+
+        self.client = OpenAI(
+            api_key=api_key,
+            base_url=base_url
+        )
+        self.model = "gpt-4o-mini"  # コスト効率を考慮してminiモデルを使用
+
+    def _build_prompt(self, preferences: Dict, available_sakes: List[Sake]) -> str:
+        """
+        ユーザーの嗜好情報と利用可能な日本酒リストからプロンプトを生成
+
+        Args:
+            preferences: ユーザーの嗜好情報（甘さ、香り、地域など）
+            available_sakes: データベースから取得した日本酒のリスト
+
+        Returns:
+            GPTに送信するプロンプト文字列
+        """
+        # 日本酒リストをテキスト形式に変換
+        sake_list_text = "\n".join([
+            f"- {sake.name} ({sake.category}): {sake.description[:100]}..."
+            f" [地域: {sake.region or '未指定'}, "
+            f"甘さ: {sake.sweetness_level or '未指定'}, "
+            f"香り: {sake.aroma_level or '未指定'}]"
+            for sake in available_sakes[:50]  # 最大50件に制限
+        ])
+
+        # 嗜好情報のテキスト生成
+        preference_text = f"""
+ユーザーの嗜好情報:
+- 好みの甘さ: {preferences.get('preferred_sweetness', '指定なし')} (1:辛口 〜 5:甘口)
+- 好みの香り: {preferences.get('preferred_aroma', '指定なし')} (1:控えめ 〜 5:芳醇)
+- 好みの地域: {preferences.get('preferred_region', '指定なし')}
+- 予算: {preferences.get('budget_min', '')}円 〜 {preferences.get('budget_max', '')}円
+- その他の希望: {preferences.get('additional_preferences', 'なし')}
+"""
+
+        prompt = f"""あなたは日本酒の専門家です。ユーザーの好みに基づいて、最適な日本酒を3〜5本レコメンドしてください。
+
+{preference_text}
+
+以下の日本酒リストから、ユーザーの好みに最も合うお酒を選んでください:
+
+{sake_list_text}
+
+回答は以下のJSON形式で返してください:
+{{
+    "recommendations": [
+        {{
+            "sake_name": "お酒の名前",
+            "reason": "このお酒を選んだ理由（ユーザーの好みとの関連を含めて）",
+            "score": 0.0-1.0のスコア（1.0が最適）,
+            "match_points": ["マッチポイント1", "マッチポイント2", ...]
+        }}
+    ]
+}}
+
+地域性や地酒の特徴も考慮して、ユーザーが地方創生の文脈で楽しめるような説明も含めてください。
+"""
+        return prompt
+
+    def get_recommendations(
+        self,
+        preferences: Dict,
+        available_sakes: Optional[List[Sake]] = None,
+        max_recommendations: int = 5
+    ) -> List[Dict]:
+        """
+        GPTを使ってレコメンドを生成
+
+        Args:
+            preferences: ユーザーの嗜好情報
+            available_sakes: 利用可能な日本酒のリスト（Noneの場合は全件取得）
+            max_recommendations: 最大レコメンド数
+
+        Returns:
+            レコメンド結果のリスト
+        """
+        # 日本酒リストを取得
+        if available_sakes is None:
+            available_sakes = list(Sake.objects.all())
+
+        if not available_sakes:
+            return []
+
+        # プロンプトを生成
+        prompt = self._build_prompt(preferences, available_sakes)
+
+        try:
+            # GPT APIを呼び出し
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "あなたは日本酒の専門家です。ユーザーの好みに基づいて、最適な日本酒をレコメンドしてください。回答は必ずJSON形式で返してください。"
+                    },
+                    {
+                        "role": "user",
+                        "content": prompt
+                    }
+                ],
+                temperature=0.7,
+                response_format={"type": "json_object"}  # JSON形式で返すことを強制
+            )
+
+            # レスポンスをパース
+            content = response.choices[0].message.content
+            result = json.loads(content)
+
+            recommendations = result.get("recommendations", [])
+
+            # 日本酒名からSakeオブジェクトをマッチング
+            enhanced_recommendations = []
+            for rec in recommendations[:max_recommendations]:
+                sake_name = rec.get("sake_name", "")
+                # 名前で部分一致検索
+                matching_sake = None
+                for sake in available_sakes:
+                    if sake.name in sake_name or sake_name in sake.name:
+                        matching_sake = sake
+                        break
+
+                enhanced_rec = {
+                    "sake": matching_sake,
+                    "sake_name": sake_name,
+                    "reason": rec.get("reason", ""),
+                    "score": float(rec.get("score", 0.5)),
+                    "match_points": rec.get("match_points", []),
+                    "gpt_reason": rec.get("reason", "")
+                }
+                enhanced_recommendations.append(enhanced_rec)
+
+            return enhanced_recommendations
+
+        except json.JSONDecodeError as e:
+            print(f"JSON解析エラー: {e}")
+            print(f"レスポンス内容: {content}")
+            return []
+        except Exception as e:
+            print(f"GPT API呼び出しエラー: {e}")
+            return []

--- a/backend/ai_recommend/urls.py
+++ b/backend/ai_recommend/urls.py
@@ -2,5 +2,8 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("recommend/", views.recommend_list, name="recommend_list"),
+    path("recommend/", views.create_recommendation,
+         name="create_recommendation"),  # POST: レコメンド生成
+    path("recommendations/", views.get_recommendations,
+         name="get_recommendations"),  # GET: レコメンド一覧取得
 ]

--- a/backend/ai_recommend/views.py
+++ b/backend/ai_recommend/views.py
@@ -1,18 +1,184 @@
+"""
+AIレコメンド機能のビュー
+"""
+import json
 from django.http import JsonResponse
-from .models import RecommendedItem
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+from django.utils.decorators import method_decorator
+from .models import RecommendedItem, UserPreference
+from .services import AIRecommendationService
+from api.models import Sake
 
 
-def recommend_list(request):
-    # 仮：score が高い順に上位5件返す
-    items = RecommendedItem.objects.order_by("-score")[:5]
-    data = [
-        {
-            "id": item.id,
-            "title": item.title,
-            "description": item.description,
-            "category": item.category,
-            "score": item.score,
+@csrf_exempt
+@require_http_methods(["POST"])
+def create_recommendation(request):
+    """
+    POST /ai_recommend/recommend/
+    ユーザーの嗜好情報を受け取り、GPTを使ってレコメンドを生成する
+
+    リクエストボディ例:
+    {
+        "user_supa_id": "uuid-string",
+        "preferred_sweetness": 3,
+        "preferred_aroma": 4,
+        "preferred_region": "新潟県",
+        "budget_min": 1000,
+        "budget_max": 5000,
+        "additional_preferences": "フルーティーな香りが好き"
+    }
+    """
+    try:
+        # リクエストボディをパース
+        data = json.loads(request.body)
+        user_supa_id = data.get("user_supa_id")
+
+        if not user_supa_id:
+            return JsonResponse(
+                {"error": "user_supa_id は必須です"},
+                status=400
+            )
+
+        # 嗜好情報を取得
+        preferences_data = {
+            "preferred_sweetness": data.get("preferred_sweetness"),
+            "preferred_aroma": data.get("preferred_aroma"),
+            "preferred_region": data.get("preferred_region", ""),
+            "budget_min": data.get("budget_min"),
+            "budget_max": data.get("budget_max"),
+            "additional_preferences": data.get("additional_preferences", "")
         }
-        for item in items
-    ]
-    return JsonResponse({"recommendations": data})
+
+        # UserPreferenceを保存または更新
+        user_preference, created = UserPreference.objects.update_or_create(
+            user_supa_id=user_supa_id,
+            defaults=preferences_data
+        )
+
+        # GPTサービスを使ってレコメンドを生成
+        service = AIRecommendationService()
+        gpt_recommendations = service.get_recommendations(preferences_data)
+
+        # RecommendedItemとして保存
+        saved_items = []
+        for rec in gpt_recommendations:
+            # 既存のレコメンドを削除（同じユーザー・同じお酒の場合）
+            RecommendedItem.objects.filter(
+                user_supa_id=user_supa_id,
+                sake=rec.get("sake")
+            ).delete()
+
+            # 新しいレコメンドを作成
+            recommended_item = RecommendedItem.objects.create(
+                sake=rec.get("sake"),
+                user_supa_id=user_supa_id,
+                user_preference=user_preference,
+                title=rec.get("sake_name", ""),
+                description=rec.get("reason", ""),
+                score=rec.get("score", 0.0),
+                gpt_reason=rec.get("gpt_reason", ""),
+                category=rec.get("sake").category if rec.get("sake") else ""
+            )
+            saved_items.append(recommended_item)
+
+        # レスポンスを生成
+        response_data = {
+            "user_supa_id": user_supa_id,
+            "recommendations": [
+                {
+                    "id": item.id,
+                    "sake_id": item.sake.id if item.sake else None,
+                    "sake_name": item.title,
+                    "description": item.description,
+                    "category": item.category,
+                    "score": item.score,
+                    "gpt_reason": item.gpt_reason,
+                    "sake_details": {
+                        "name": item.sake.name if item.sake else item.title,
+                        "region": item.sake.region if item.sake else None,
+                        "sweetness_level": item.sake.sweetness_level if item.sake else None,
+                        "aroma_level": item.sake.aroma_level if item.sake else None,
+                        "brewery": item.sake.brewery.name if item.sake and item.sake.brewery else None,
+                    } if item.sake else None
+                }
+                for item in saved_items
+            ]
+        }
+
+        return JsonResponse(response_data, status=201)
+
+    except json.JSONDecodeError:
+        return JsonResponse(
+            {"error": "無効なJSON形式です"},
+            status=400
+        )
+    except ValueError as e:
+        return JsonResponse(
+            {"error": str(e)},
+            status=500
+        )
+    except Exception as e:
+        return JsonResponse(
+            {"error": f"レコメンド生成中にエラーが発生しました: {str(e)}"},
+            status=500
+        )
+
+
+@require_http_methods(["GET"])
+def get_recommendations(request):
+    """
+    GET /ai_recommend/recommendations/
+    レコメンド一覧を取得する
+
+    クエリパラメータ:
+    - user_supa_id: ユーザーID（指定した場合はそのユーザーのレコメンドのみ）
+    - limit: 取得件数（デフォルト: 10）
+    """
+    try:
+        user_supa_id = request.GET.get("user_supa_id")
+        limit = int(request.GET.get("limit", 10))
+
+        # クエリセットを構築
+        queryset = RecommendedItem.objects.all()
+
+        if user_supa_id:
+            queryset = queryset.filter(user_supa_id=user_supa_id)
+
+        # スコア順でソートして取得
+        items = queryset.order_by("-score", "-created_at")[:limit]
+
+        data = [
+            {
+                "id": item.id,
+                "sake_id": item.sake.id if item.sake else None,
+                "sake_name": item.title,
+                "description": item.description,
+                "category": item.category,
+                "score": item.score,
+                "gpt_reason": item.gpt_reason,
+                "sake_details": {
+                    "name": item.sake.name if item.sake else item.title,
+                    "region": item.sake.region if item.sake else None,
+                    "sweetness_level": item.sake.sweetness_level if item.sake else None,
+                    "aroma_level": item.sake.aroma_level if item.sake else None,
+                    "brewery": item.sake.brewery.name if item.sake and item.sake.brewery else None,
+                    "description": item.sake.description if item.sake else None,
+                } if item.sake else None,
+                "created_at": item.created_at.isoformat(),
+            }
+            for item in items
+        ]
+
+        return JsonResponse({"recommendations": data}, status=200)
+
+    except ValueError:
+        return JsonResponse(
+            {"error": "limit は数値である必要があります"},
+            status=400
+        )
+    except Exception as e:
+        return JsonResponse(
+            {"error": f"レコメンド取得中にエラーが発生しました: {str(e)}"},
+            status=500
+        )

--- a/backend/api/migrations/0002_add_ai_recommend_fields.py
+++ b/backend/api/migrations/0002_add_ai_recommend_fields.py
@@ -1,0 +1,52 @@
+# Generated manually to add AI recommend fields to Sake model
+
+from django.db import migrations, models
+import django.utils.timezone
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sake',
+            name='region',
+            field=models.CharField(blank=True, max_length=100),
+        ),
+        migrations.AddField(
+            model_name='sake',
+            name='brewery',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='sakes', to='api.brewery'),
+        ),
+        migrations.AddField(
+            model_name='sake',
+            name='sweetness_level',
+            field=models.IntegerField(blank=True, help_text='甘さの度合い（1:辛口 〜 5:甘口）', null=True),
+        ),
+        migrations.AddField(
+            model_name='sake',
+            name='aroma_level',
+            field=models.IntegerField(blank=True, help_text='香りの強さ（1:控えめ 〜 5:芳醇）', null=True),
+        ),
+        migrations.AddField(
+            model_name='sake',
+            name='alcohol_content',
+            field=models.FloatField(blank=True, help_text='アルコール度数', null=True),
+        ),
+        migrations.AddField(
+            model_name='sake',
+            name='price_range',
+            field=models.CharField(blank=True, help_text='価格帯（例: 1000-2000円）', max_length=50),
+        ),
+        migrations.AddField(
+            model_name='sake',
+            name='created_at',
+            field=models.DateTimeField(auto_now_add=True, default=django.utils.timezone.now),
+            preserve_default=False,
+        ),
+    ]
+

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -7,7 +7,19 @@ class Sake(models.Model):
     name = models.CharField(max_length=100)
     category = models.CharField(max_length=50)  # 例: 純米酒, 吟醸酒
     description = models.TextField()
-    # その他、産地、アルコール度数などのカラムを追加
+    # AIレコメンド用の追加フィールド
+    region = models.CharField(max_length=100, blank=True)  # 産地・地域
+    brewery = models.ForeignKey(
+        "Brewery", on_delete=models.SET_NULL, null=True, blank=True, related_name="sakes")  # 酒蔵
+    sweetness_level = models.IntegerField(
+        null=True, blank=True, help_text="甘さの度合い（1:辛口 〜 5:甘口）")
+    aroma_level = models.IntegerField(
+        null=True, blank=True, help_text="香りの強さ（1:控えめ 〜 5:芳醇）")
+    alcohol_content = models.FloatField(
+        null=True, blank=True, help_text="アルコール度数")
+    price_range = models.CharField(
+        max_length=50, blank=True, help_text="価格帯（例: 1000-2000円）")
+    created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
         return self.name
@@ -37,9 +49,12 @@ class Event(models.Model):
 
 
 class Review(models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-    sake = models.ForeignKey("Sake", on_delete=models.CASCADE, null=True, blank=True)
-    event = models.ForeignKey("Event", on_delete=models.CASCADE, null=True, blank=True)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL,
+                             on_delete=models.CASCADE)
+    sake = models.ForeignKey(
+        "Sake", on_delete=models.CASCADE, null=True, blank=True)
+    event = models.ForeignKey(
+        "Event", on_delete=models.CASCADE, null=True, blank=True)
     rating = models.IntegerField()  # 例: 1〜5の5段階評価
     comment = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)

--- a/backend/check_database.py
+++ b/backend/check_database.py
@@ -1,0 +1,81 @@
+"""
+Supabaseデータベースの状態を確認するスクリプト
+"""
+import os
+import sys
+import django
+
+# Djangoの設定を読み込む
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'myproject.settings')
+django.setup()
+
+from api.models import Sake, Brewery
+from ai_recommend.models import UserPreference, RecommendedItem
+
+
+def check_database():
+    """データベースの状態を確認"""
+    print("=" * 60)
+    print("データベース確認")
+    print("=" * 60)
+    
+    # Sakeデータの確認
+    print("\n【Sake（日本酒）データ】")
+    sake_count = Sake.objects.count()
+    print(f"  登録数: {sake_count}件")
+    
+    if sake_count > 0:
+        print("\n  登録されている日本酒:")
+        for sake in Sake.objects.all()[:10]:  # 最大10件表示
+            print(f"    - {sake.name} ({sake.category})")
+            print(f"      地域: {sake.region or '未設定'}, "
+                  f"甘さ: {sake.sweetness_level or '未設定'}, "
+                  f"香り: {sake.aroma_level or '未設定'}")
+        if sake_count > 10:
+            print(f"    ... 他 {sake_count - 10}件")
+    else:
+        print("  ⚠️ データがありません")
+    
+    # Breweryデータの確認
+    print("\n【Brewery（酒蔵）データ】")
+    brewery_count = Brewery.objects.count()
+    print(f"  登録数: {brewery_count}件")
+    
+    if brewery_count > 0:
+        print("\n  登録されている酒蔵:")
+        for brewery in Brewery.objects.all()[:5]:
+            print(f"    - {brewery.name}")
+    
+    # UserPreferenceデータの確認
+    print("\n【UserPreference（ユーザー嗜好）データ】")
+    preference_count = UserPreference.objects.count()
+    print(f"  登録数: {preference_count}件")
+    
+    # RecommendedItemデータの確認
+    print("\n【RecommendedItem（レコメンド結果）データ】")
+    recommendation_count = RecommendedItem.objects.count()
+    print(f"  登録数: {recommendation_count}件")
+    
+    print("\n" + "=" * 60)
+    
+    # データベース接続の確認
+    from django.db import connection
+    print("\n【データベース接続情報】")
+    db_settings = connection.settings_dict
+    print(f"  データベース: {db_settings.get('NAME', 'N/A')}")
+    print(f"  ホスト: {db_settings.get('HOST', 'N/A')}")
+    print(f"  ポート: {db_settings.get('PORT', 'N/A')}")
+    print(f"  ユーザー: {db_settings.get('USER', 'N/A')}")
+    
+    print("\n" + "=" * 60)
+
+
+if __name__ == "__main__":
+    try:
+        check_database()
+    except Exception as e:
+        print(f"\n❌ エラーが発生しました: {e}")
+        print("\nデータベース接続を確認してください。")
+        sys.exit(1)
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ djangorestframework
 psycopg[binary]
 dj-database-url
 python-dotenv
+openai>=1.0.0


### PR DESCRIPTION
- データモデルの拡張
  - Sakeモデルに地域、甘さ、香り、価格帯などのフィールドを追加
  - UserPreferenceモデルを新規作成（ユーザーの嗜好情報を保存）
  - RecommendedItemモデルをSakeモデルと関連付け、GPTレコメンド結果を保存

- GPT連携サービスの実装
  - OpenAI APIクライアントの実装（カスタムエンドポイント対応）
  - ユーザーの嗜好情報を分析してレコメンドを生成するロジック
  - 地域性・地酒の情報を含むプロンプト設計

- APIエンドポイントの追加
  - POST /ai_recommend/recommend/ - レコメンド生成
  - GET /ai_recommend/recommendations/ - レコメンド一覧取得

- マイグレーションファイル
  - apiアプリ: Sakeモデルの拡張
  - ai_recommendアプリ: UserPreference、RecommendedItemモデルの作成

- 依存関係
  - requirements.txtにopenai>=1.0.0を追加

- ドキュメント
  - 動作確認手順のREADME追加
  - Supabaseデータベース手動追加ガイド追加
  - データベース確認スクリプト追加